### PR TITLE
Re enable amd toolbox

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           file: Dockerfile
           context: .
           push: true
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           cache-to: type=gha,scope=${{ github.workflow }}
           cache-from: type=gha,scope=${{ github.workflow }}
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM redis:7.4.2-alpine
+FROM redis:7.2.4-alpine
 
 WORKDIR /root
+
+ARG TARGETARCH
 
 RUN apk upgrade --no-cache  \
     && apk add --no-cache \
@@ -13,11 +15,13 @@ RUN apk upgrade --no-cache  \
            pixz \
     && if [ "$TARGETARCH" = "arm64" ]; then \
        curl -fsSL https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl -o /usr/local/bin/kubectl \
+       && chmod u+x /usr/local/bin/kubectl; \
        elif [ "$TARGETARCH" = "amd64" ]; then \
        curl -fsSL https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+       && chmod u+x /usr/local/bin/kubectl; \
        fi \
-    && chmod u+x /usr/local/bin/kubectl \
-    && git clone --depth 1 https://github.com/Bash-it/bash-it.git /root/.bash_it
+    && git clone --depth 1 https://github.com/Bash-it/bash-it.git /root/.bash_it \
+    && rm -rf /var/cache/apk/*
 
 COPY bashrc .bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ RUN apk upgrade --no-cache  \
            tcpdump bind-tools py3-setuptools py3-pip \
     && apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
            pixz \
-    && curl -fsSL https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl -o /usr/local/bin/kubectl \
+    && if [ "$TARGETARCH" = "arm64" ]; then \
+       curl -fsSL https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl -o /usr/local/bin/kubectl \
+       elif [ "$TARGETARCH" = "amd64" ]; then \
+       curl -fsSL https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+       fi \
     && chmod u+x /usr/local/bin/kubectl \
     && git clone --depth 1 https://github.com/Bash-it/bash-it.git /root/.bash_it
 


### PR DESCRIPTION
 - Some workflows in juro-misc-ops use github actions written in javascript. JavaScript Actions in Alpine containers are only supported on x64 Linux runners. 